### PR TITLE
Korrektur Version

### DIFF
--- a/custom_components/manifest.json
+++ b/custom_components/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ford_triplog",
   "name": "Ford Triplog",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "documentation": "https://github.com/weberdomi-ctrl/ford-triplog",
   "issue_tracker": "https://github.com/weberdomi-ctrl/ford-triplog/issues",
   "config_flow": true,

--- a/custom_components/sensor.py
+++ b/custom_components/sensor.py
@@ -3,7 +3,7 @@ Ford Triplog
 
 Home Assistant sensor platform.
 
-Version: 1.0.0
+Version: 1.0.1
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Ford Triplog v1.0.0 Final

Erste öffentliche Version von Ford Triplog für Home Assistant.

Neu:
• Automatische Fahrterkennung über FordPass
• Speicherung aller Fahrten mit Start-/Zieladresse
• Distanz, Dauer und SOC-Verbrauch
• Gesamtkilometer, Gesamtdauer und Fahrtenzähler
• Binary Sensor "Trip Active"
• Unterstützung für FordPass-Fahrzeuge

Verbesserungen gegenüber RC2:
• Material Design Icons für alle Sensoren
• Kürzere und übersichtlichere Sensornamen
• Modernisierte binary_sensor.py
• Optimierte Darstellung im Home Assistant Dashboard

Kompatibilität:
• Home Assistant 2026.x
• FordPass Integration erforderlich

Es wurden keine Änderungen an der Fahrtenlogik oder am Speicherformat vorgenommen.
Vorhandene Fahrtdaten bleiben vollständig kompatibel.