### PR TITLE
Update route_tracker.py

### DIFF
--- a/custom_components/ford_triplog/route_tracker.py
+++ b/custom_components/ford_triplog/route_tracker.py
@@ -3,17 +3,14 @@ Ford Triplog
 
 Route Tracker
 
-Version: 2.2.0
-Phase: Route Tracker Phase 1
-Build: 03 - Trip-end GPS validation
+Version: 2.3.0
+Build: 23029 - 60 second active-route persistence
 
 Changes:
-- Persists the route record immediately when a Trip starts.
-- Persists every accepted GPS point while driving.
-- Persists Smart Trip pause/resume state.
+- Captures every accepted GPS point immediately in memory.
+- Persists active route snapshots to SQLite at most once per minute.
+- Persists start, pause/resume, shutdown and final route state immediately.
 - Restores active or paused route points after HA/integration reload.
-- Keeps Trip start/end GPS endpoint logic from Fix 05.
-- Keeps ABRP coordinate debounce/synchronization from Fix 04.
 - Raw route points remain independent from Trip/Journey storage.
 """
 
@@ -21,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import datetime
 from typing import Any
 
@@ -55,6 +53,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ABRP_DEBOUNCE_SECONDS = 0.75
 ABRP_MAX_PAIR_DELTA_SECONDS = 2.0
+ROUTE_PERSIST_INTERVAL_SECONDS = 60.0
 
 
 class FordTriplogRouteTracker:
@@ -116,6 +115,7 @@ class FordTriplogRouteTracker:
         self._last_coordinate: tuple[float, float] | None = None
         self._debounce_task: asyncio.Task | None = None
         self._persist_lock = asyncio.Lock()
+        self._last_persist_monotonic: float | None = None
         self._route_created_at: str | None = None
 
     async def async_setup(self) -> None:
@@ -480,6 +480,7 @@ class FordTriplogRouteTracker:
         self.points = []
         self._last_coordinate = None
         self._route_created_at = None
+        self._last_persist_monotonic = None
         self.route_source_type = self.source_type
 
         _LOGGER.info(
@@ -667,27 +668,53 @@ class FordTriplogRouteTracker:
         )
         self._last_coordinate = coordinate_key
 
-        # Fix 06: one ~60 s ABRP point means one small atomic JSON write.
-        # This is intentionally simple and makes crash/reload recovery robust.
-        await self._persist_current_route("active")
-
-        _LOGGER.debug(
-            "Route Tracker point persisted: trip=%s points=%s",
-            self.active_trip_id,
-            len(self.points),
+        # Dense sources such as the Home Assistant Companion App can update
+        # every few seconds. Keep every point in memory, but avoid rewriting the
+        # growing SQLite route payload on every coordinate update.
+        persisted = await self._persist_current_route(
+            "active",
+            force=False,
         )
+
+        if persisted:
+            _LOGGER.debug(
+                "Route Tracker snapshot persisted: trip=%s points=%s "
+                "interval=%ss",
+                self.active_trip_id,
+                len(self.points),
+                int(ROUTE_PERSIST_INTERVAL_SECONDS),
+            )
 
     async def _persist_current_route(
         self,
         status: str,
-    ) -> None:
-        """Persist the current route snapshot atomically."""
+        *,
+        force: bool = True,
+    ) -> bool:
+        """Persist the current route snapshot atomically.
+
+        Active GPS capture uses ``force=False`` so the growing route payload is
+        written at most once per minute. Lifecycle transitions continue to use
+        the default ``force=True`` and are therefore saved immediately.
+        """
 
         trip_id = self.active_trip_id or self.paused_trip_id
         if trip_id is None:
-            return
+            return False
 
         async with self._persist_lock:
+            now_monotonic = time.monotonic()
+
+            if (
+                not force
+                and self._last_persist_monotonic is not None
+                and (
+                    now_monotonic - self._last_persist_monotonic
+                    < ROUTE_PERSIST_INTERVAL_SECONDS
+                )
+            ):
+                return False
+
             await self.storage.async_save_route(
                 trip_id=trip_id,
                 source_type=self.route_source_type,
@@ -695,6 +722,9 @@ class FordTriplogRouteTracker:
                 status=status,
                 created_at=self._route_created_at,
             )
+            self._last_persist_monotonic = time.monotonic()
+
+        return True
 
     def _read_coordinates(
         self,


### PR DESCRIPTION
## 2.3.0

### Added

-   SQLite is now the sole productive Ford Triplog storage backend.
-   Added one-time legacy JSON import paths with persistent migration
    markers so already migrated legacy data is not scanned again on every
    Home Assistant restart.
-   Added direct Home Assistant `device_tracker` support as a Route
    Tracker GPS source.
-   Added Route maintenance actions for rebuilding the latest route,
    raw/failed routes or all stored routes through the configured OSRM
    server.
-   Added OSRM chunked map matching for dense GPS traces that exceed the
    common OSRM limit of 100 trace coordinates per request.

### Improved

-   Trip-end GPS selection now compares the latest valid point from the
    configured Route Tracker source with the vehicle tracker and uses the
    point with the newest timestamp after the Smart Trip timeout.
-   Home Assistant Companion App high-accuracy `device_tracker` data can
    be recorded directly without going through the slower Geocoded
    Location sensor.
-   OSRM matching now processes long traces in overlapping chunks while
    preserving the original raw GPS points.
-   OSRM requests use `tidy=false` so returned tracepoints stay aligned
    with the submitted GPS points and matching diagnostics remain
    meaningful.
-   The Last Route sensor now follows the latest completed stored route
    and refreshes safely through Home Assistant's event loop.
-   The public **Last Tour** view now represents the latest completed
    individual Trip rather than a complete Journey/day aggregation.
-   Route rebuilds preserve the original raw trace and replace matched
    route geometry only after a successful plausibility check.
-   Source selectors now prevent Ford Triplog's own entities from being
    selected as vehicle or Route Tracker input sources.
-   Removed remaining normal-runtime dependency on parallel JSON/SQLite
    production storage.

### Fixed

-   Fixed stale or early route endpoints when the vehicle tracker
    received a newer GPS fix after ignition-off.
-   Fixed OSRM `TooBig` failures for dense Route Tracker traces with more
    than 100 GPS points.
-   Fixed false OSRM rejection caused by `tidy=true` changing the
    tracepoint/input alignment.
-   Fixed thread-unsafe Last Route refresh scheduling.
-   Fixed repeated legacy migration scans after successful SQLite
    migration.
-   Fixed configuration paths that could allow Ford Triplog output
    entities to be selected as their own input source.

### Storage Notes

-   Existing JSON data remains usable as a migration/import source and
    backup, but it is no longer maintained as a parallel production
    datastore.
-   Receipts remain stored as files and their metadata remains linked
    through Ford Triplog storage.
-   Raw GPS route points remain preserved independently from OSRM-matched
    route geometry.