### PR TITLE
2.3

### DIFF
--- a/custom_components/ford_triplog/charge_manager.py
+++ b/custom_components/ford_triplog/charge_manager.py
@@ -483,11 +483,19 @@ class FordTriplogChargeManager:
         parking_fee: float | None = None,
         other_cost: float | None = None,
         energy_billed_source: str = "manual",
+        cost_source: str = "manual",
     ) -> ChargeManagerResult:
-        """Set and verify detailed manual costs for one charging session."""
+        """Set and verify detailed costs for one charging session."""
 
         normalized_id = self._normalize_charge_id(charge_id)
         normalized_currency = self._normalize_currency(currency)
+        normalized_cost_source = str(
+            cost_source or "manual"
+        ).strip().lower()
+        if normalized_cost_source not in {"manual", "ocr"}:
+            raise ValueError(
+                f"Unsupported charging cost source: {normalized_cost_source}"
+            )
 
         normalized_cost = self._normalize_optional_cost(cost_total)
         normalized_energy_billed = self._normalize_optional_cost(
@@ -550,9 +558,10 @@ class FordTriplogChargeManager:
         )
 
         charge.currency = normalized_currency
-        charge.cost_source = "manual"
+        charge.cost_source = normalized_cost_source
         charge.cost_verified = True
-        # Keep an existing receipt filename when manually updating costs.
+        # Keep an existing receipt filename when updating costs manually or
+        # from OCR/parser data.
         charge.recalculate_costs()
 
         saved = await self.storage.update_charge(

--- a/custom_components/ford_triplog/charging_costs.py
+++ b/custom_components/ford_triplog/charging_costs.py
@@ -104,15 +104,18 @@ class FordTriplogChargingCostCalculator:
         if zone_state is None:
             return False
 
+        # A completed charging session should be classified by the newest
+        # known charging position. Start GPS can still be stale from the trip
+        # immediately before plugging in.
         latitude = (
-            charge.start_latitude
-            if charge.start_latitude is not None
-            else charge.end_latitude
+            charge.end_latitude
+            if charge.end_latitude is not None
+            else charge.start_latitude
         )
         longitude = (
-            charge.start_longitude
-            if charge.start_longitude is not None
-            else charge.end_longitude
+            charge.end_longitude
+            if charge.end_longitude is not None
+            else charge.start_longitude
         )
 
         try:
@@ -185,11 +188,34 @@ class FordTriplogChargingCostCalculator:
             getattr(charge, "cost_source", "none") or "none"
         ).strip().lower()
 
+        is_home_charge = self._is_home_charge(charge)
+
+        # Remove an earlier automatic Home tariff when repaired/newer GPS
+        # proves that the charging session was not at Home. Never touch manual
+        # or OCR costs.
+        if cost_source == "home_tariff" and (
+            not allow_automatic_tariff
+            or not self.home_tariff_enabled
+            or not is_home_charge
+        ):
+            charge.energy_cost = None
+            charge.session_fee = None
+            charge.time_fee = None
+            charge.blocking_fee = None
+            charge.parking_fee = None
+            charge.other_cost = None
+            charge.cost_total = None
+            charge.currency = None
+            charge.cost_source = "none"
+            charge.cost_verified = False
+            charge.recalculate_costs()
+            cost_source = "none"
+
         if (
             allow_automatic_tariff
             and cost_source not in _PROTECTED_COST_SOURCES
             and self.home_tariff_enabled
-            and self._is_home_charge(charge)
+            and is_home_charge
         ):
             start_time = self._parse_datetime(charge.start_time)
             energy, energy_source = self._pricing_energy(charge)

--- a/custom_components/ford_triplog/config_flow.py
+++ b/custom_components/ford_triplog/config_flow.py
@@ -1530,6 +1530,8 @@ class FordTriplogOptionsFlow(OptionsFlow):
         menu_options = ["charge_receipt_open"]
         if bool(self._options.get(CONF_OCR_ENABLED, False)):
             menu_options.append("charge_receipt_ocr")
+        if str(receipt.get("parse_status") or "") == "parsed":
+            menu_options.append("charge_receipt_apply")
         if (
             str(receipt.get("ocr_status") or "") == "completed"
             and str(receipt.get("parse_status") or "") != "parsed"
@@ -1547,6 +1549,18 @@ class FordTriplogOptionsFlow(OptionsFlow):
             menu_options=menu_options,
             description_placeholders=placeholders,
         )
+
+    async def async_step_charge_receipt_apply(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Review and apply parser values for the selected charge receipt."""
+
+        if not self._selected_receipt_id:
+            return await self.async_step_charge_receipt_list()
+
+        self._selected_apply_receipt_id = self._selected_receipt_id
+        return await self.async_step_receipt_apply_edit()
 
     async def async_step_charge_receipt_open(
         self,
@@ -2937,6 +2951,7 @@ class FordTriplogOptionsFlow(OptionsFlow):
             [
                 "receipt_import_type",
                 "receipt_list",
+                "receipt_apply",
                 "receipt_delete",
             ]
         )

--- a/custom_components/ford_triplog/config_flow.py
+++ b/custom_components/ford_triplog/config_flow.py
@@ -946,6 +946,11 @@ class FordTriplogOptionsFlow(OptionsFlow):
             description_placeholders={
                 "receipt_count": str(len(receipts)),
                 "receipt_summary": receipt_summary,
+                "ocr_status": (
+                    ui_text["ocr_enabled"]
+                    if bool(self._options.get(CONF_OCR_ENABLED, False))
+                    else ui_text["ocr_disabled"]
+                ),
             },
         )
 

--- a/custom_components/ford_triplog/coordinator.py
+++ b/custom_components/ford_triplog/coordinator.py
@@ -4,13 +4,16 @@ Ford Triplog
 Coordinator
 
 Version: 2.3.0
-Build: 23030 - Trip transition race guard
+Build: 23031 - Charging recovery and Last Charge guard
 
 Changes:
-- Claims ignition and charging state transitions before awaiting handlers.
-- Prevents concurrent Home Assistant state events from starting/ending the same trip twice.
-- Sets the trip-finalization guard before pausing the Route Tracker.
-- Keeps Smart Trip, Route Tracker and charging behavior otherwise unchanged.
+- Discards stale current_charge recovery records that are already archived.
+- Prevents an archived charge ID from blocking a newly started charging session.
+- Requires FordPass Last Charge end timestamps to match the local charge end.
+- Recovers a very recent missing FordPass Last Charge after restart when safe.
+- Repairs grossly corrupted archived charge end data from its embedded FordPass snapshot.
+- Removes a duplicate pending-charge timeout resume call.
+- Keeps the Build 23030 trip transition race guard.
 """
 
 from __future__ import annotations
@@ -272,7 +275,16 @@ class FordTriplogCoordinator(DataUpdateCoordinator):
           
         data = await self.storage.load_current_charge()
         if data:
-            self.current_charge = Charge.from_dict(data)        
+            recovered_charge = Charge.from_dict(data)
+            if await self._charge_id_is_archived(recovered_charge.charge_id):
+                _LOGGER.warning(
+                    "Discarding stale current charge recovery %s because "
+                    "the same charge is already archived",
+                    recovered_charge.charge_id,
+                )
+                await self.storage.delete_current_charge()
+            else:
+                self.current_charge = recovered_charge
 
 
         entities = [
@@ -298,6 +310,12 @@ class FordTriplogCoordinator(DataUpdateCoordinator):
             self.last_charge_signature = self._last_charge_to_signature(
                 last_charge
             )
+
+        # Repair one stale archived session if its embedded FordPass dataset
+        # proves that the local end data was accidentally extended. Then
+        # recover a very recent FordPass Last Charge that is not represented
+        # in SQLite (for example after a stale current_charge blocked start).
+        await self._async_reconcile_last_charge_archive()
 
         # Resume a pending completed charging session from recovery. The
         # timeout is measured from the recorded charge end time, so a Home
@@ -929,6 +947,345 @@ class FordTriplogCoordinator(DataUpdateCoordinator):
 
         return parsed
 
+    async def _charge_id_is_archived(self, charge_id: Any) -> bool:
+        """Return whether a charge ID already exists in the SQLite archive."""
+
+        normalized = str(charge_id or "").strip()
+        if not normalized:
+            return False
+
+        archived = await self.storage.load_archived_charges()
+        return any(
+            str(item.get("charge_id") or "").strip() == normalized
+            for item in archived
+            if isinstance(item, dict)
+        )
+
+    @classmethod
+    def _fordpass_snapshot_times(
+        cls,
+        snapshot: dict[str, Any] | None,
+    ) -> tuple[datetime | None, datetime | None]:
+        """Return FordPass charge begin/end timestamps from a snapshot."""
+
+        if not isinstance(snapshot, dict):
+            return None, None
+
+        ford_start = cls._parse_fordpass_datetime(
+            cls._snapshot_attribute(
+                snapshot,
+                "energyTransferDuration",
+                "begin",
+            )
+            or cls._snapshot_attribute(
+                snapshot,
+                "plugDetails",
+                "plugInTime",
+            )
+        )
+        ford_end = cls._parse_fordpass_datetime(
+            cls._snapshot_attribute(
+                snapshot,
+                "energyTransferDuration",
+                "end",
+            )
+            or cls._snapshot_attribute(
+                snapshot,
+                "plugDetails",
+                "plugOutTime",
+            )
+            or cls._snapshot_attribute(snapshot, "timeStamp")
+        )
+        return ford_start, ford_end
+
+    @classmethod
+    def _archived_charge_represents_snapshot(
+        cls,
+        charge: dict[str, Any],
+        snapshot: dict[str, Any],
+    ) -> bool:
+        """Return whether an archived charge already represents FordPass data."""
+
+        ford_start, ford_end = cls._fordpass_snapshot_times(snapshot)
+        if ford_end is None:
+            return False
+
+        embedded = charge.get("fordpass_last_charge")
+        if isinstance(embedded, dict):
+            embedded_start, embedded_end = cls._fordpass_snapshot_times(
+                embedded
+            )
+            if (
+                embedded_end is not None
+                and abs((embedded_end - ford_end).total_seconds()) <= 60
+                and (
+                    ford_start is None
+                    or embedded_start is None
+                    or abs(
+                        (embedded_start - ford_start).total_seconds()
+                    ) <= 60
+                )
+            ):
+                return True
+
+        local_start = cls._parse_fordpass_datetime(charge.get("start_time"))
+        local_end = cls._parse_fordpass_datetime(charge.get("end_time"))
+        if local_end is None:
+            return False
+
+        end_matches = abs((local_end - ford_end).total_seconds()) <= 900
+        if ford_start is None or local_start is None:
+            return end_matches
+
+        return (
+            end_matches
+            and abs((local_start - ford_start).total_seconds()) <= 900
+        )
+
+    @classmethod
+    def _charge_from_fordpass_snapshot(
+        cls,
+        snapshot: dict[str, Any],
+    ) -> Charge | None:
+        """Build a completed Charge from one FordPass Last Charge dataset."""
+
+        ford_start, ford_end = cls._fordpass_snapshot_times(snapshot)
+        if ford_start is None or ford_end is None:
+            return None
+
+        attributes = snapshot.get("attributes")
+        if not isinstance(attributes, dict):
+            return None
+
+        local_start = dt_util.as_local(ford_start)
+        local_end = dt_util.as_local(ford_end)
+
+        charge = Charge()
+        charge.charge_id = local_start.strftime("%Y%m%dT%H%M%S")
+        charge.created = local_start.isoformat()
+        charge.start_time = local_start.isoformat()
+        charge.end_time = local_end.isoformat()
+        charge.start_soc = Charge._optional_float(
+            cls._snapshot_attribute(snapshot, "stateOfCharge", "firstSOC")
+        )
+        charge.end_soc = Charge._optional_float(
+            cls._snapshot_attribute(snapshot, "stateOfCharge", "lastSOC")
+        )
+
+        location = attributes.get("location")
+        if isinstance(location, dict):
+            latitude = Charge._optional_float(location.get("latitude"))
+            longitude = Charge._optional_float(location.get("longitude"))
+            charge.start_latitude = latitude
+            charge.start_longitude = longitude
+            charge.end_latitude = latitude
+            charge.end_longitude = longitude
+
+            raw_address = location.get("address")
+            if isinstance(raw_address, dict):
+                address_1 = str(raw_address.get("address1") or "").strip()
+                postcode = str(raw_address.get("postalCode") or "").strip()
+                city = str(raw_address.get("city") or "").strip()
+                state = str(raw_address.get("state") or "").strip()
+                country = str(raw_address.get("country") or "").strip()
+                display = ", ".join(
+                    part
+                    for part in (
+                        address_1,
+                        " ".join(part for part in (postcode, city) if part),
+                        state,
+                        country,
+                    )
+                    if part
+                )
+                normalized_address = {
+                    "display": display or None,
+                    "road": address_1 or None,
+                    "house_number": None,
+                    "postcode": postcode or None,
+                    "city": city or None,
+                    "state": state or None,
+                    "country": country or None,
+                    "latitude": latitude,
+                    "longitude": longitude,
+                    "source": "fordpass",
+                }
+                charge.start_address = dict(normalized_address)
+                charge.end_address = dict(normalized_address)
+
+        charge.fordpass_last_charge = dict(snapshot)
+        charge.fordpass_pending = False
+        charge.data_source = "fordpass"
+        return charge
+
+    async def _async_repair_archived_charge_from_snapshot(
+        self,
+        data: dict[str, Any],
+    ) -> bool:
+        """Repair a charge whose end was grossly extended past FordPass."""
+
+        snapshot = data.get("fordpass_last_charge")
+        if not isinstance(snapshot, dict):
+            return False
+
+        ford_start, ford_end = self._fordpass_snapshot_times(snapshot)
+        local_start = self._parse_fordpass_datetime(data.get("start_time"))
+        local_end = self._parse_fordpass_datetime(data.get("end_time"))
+
+        if (
+            ford_start is None
+            or ford_end is None
+            or local_start is None
+            or local_end is None
+        ):
+            return False
+
+        # Only heal a clear corruption: the original start still matches the
+        # FordPass session, but the stored end drifted by more than one hour.
+        if abs((local_start - ford_start).total_seconds()) > 900:
+            return False
+        if abs((local_end - ford_end).total_seconds()) <= 24 * 3600:
+            return False
+
+        charge = Charge.from_dict(data)
+        charge.end_time = dt_util.as_local(ford_end).isoformat()
+        charge.start_soc = Charge._optional_float(
+            self._snapshot_attribute(snapshot, "stateOfCharge", "firstSOC")
+        )
+        charge.end_soc = Charge._optional_float(
+            self._snapshot_attribute(snapshot, "stateOfCharge", "lastSOC")
+        )
+
+        attributes = snapshot.get("attributes")
+        location = attributes.get("location") if isinstance(attributes, dict) else None
+        if isinstance(location, dict):
+            latitude = Charge._optional_float(location.get("latitude"))
+            longitude = Charge._optional_float(location.get("longitude"))
+            if latitude is not None and longitude is not None:
+                charge.end_latitude = latitude
+                charge.end_longitude = longitude
+                if charge.start_latitude is None or charge.start_longitude is None:
+                    charge.start_latitude = latitude
+                    charge.start_longitude = longitude
+                # The start address belongs to the original session and is a
+                # safer fallback than the accidentally captured later address.
+                if charge.start_address is not None:
+                    charge.end_address = charge.start_address
+
+        # Drop the wrongly resolved site and resolve it again from repaired GPS.
+        charge.charging_site_id = None
+        charge.charging_site_name = None
+        charge.charging_site_brand = None
+        charge.charging_site_operator = None
+        charge.charging_site_network = None
+        charge.charging_site_power_kw = []
+        charge.charging_site_capacity = []
+        charge.charging_site_connectors = []
+        charge.charging_site_quality = None
+        charge.charging_site_distance_m = None
+
+        charge = await self.charging_location_resolver.async_resolve(charge)
+
+        start_soc = float(charge.start_soc or 0)
+        end_soc = float(charge.end_soc or 0)
+        energy_calculated = round(
+            (max(0.0, end_soc - start_soc) / 100) * self.battery_capacity,
+            2,
+        )
+        raw_energy = self._snapshot_attribute(snapshot, "energyConsumed")
+        try:
+            energy_fordpass = (
+                round(float(raw_energy), 2)
+                if raw_energy is not None
+                else None
+            )
+        except (TypeError, ValueError):
+            energy_fordpass = None
+
+        charge.energy_added_kwh_calculated = energy_calculated
+        charge.energy_added_kwh_fordpass = energy_fordpass
+        charge.energy_added_kwh = energy_calculated
+        charge.energy_source = "calculated"
+        await self._apply_home_charging_costs(charge)
+
+        repaired_data = charge.to_dict()
+        saved = await self.storage.save_charge(repaired_data)
+        if saved:
+            cached_last = await self.storage.load_last_charge()
+            if (
+                isinstance(cached_last, dict)
+                and str(cached_last.get("charge_id") or "").strip()
+                == str(charge.charge_id or "").strip()
+            ):
+                await self.storage.save_last_charge(repaired_data)
+
+            _LOGGER.warning(
+                "Repaired archived charging session %s from embedded "
+                "FordPass timestamps",
+                charge.charge_id,
+            )
+        return saved
+
+    async def _async_reconcile_last_charge_archive(self) -> None:
+        """Repair stale charge data and backfill a recent missing Last Charge."""
+
+        archived = await self.storage.load_archived_charges()
+        repaired = False
+        for item in archived:
+            if isinstance(item, dict):
+                repaired = (
+                    await self._async_repair_archived_charge_from_snapshot(item)
+                    or repaired
+                )
+
+        if repaired:
+            archived = await self.storage.load_archived_charges()
+            await self.history.refresh_statistics()
+
+        if self.current_charge is not None:
+            return
+
+        snapshot = self.last_charge_snapshot
+        if not isinstance(snapshot, dict):
+            return
+
+        # Never synthesize a completed charge while the vehicle is currently
+        # reporting an active charging session.
+        if str(self._read_vehicle_state().get("charging") or "").upper() == "IN_PROGRESS":
+            return
+
+        ford_start, ford_end = self._fordpass_snapshot_times(snapshot)
+        if ford_start is None or ford_end is None:
+            return
+
+        # Startup backfill is intentionally narrow: only a very recent final
+        # FordPass dataset can be imported automatically.
+        age_seconds = (dt_util.now() - ford_end).total_seconds()
+        if age_seconds < -300 or age_seconds > 6 * 3600:
+            return
+
+        if any(
+            self._archived_charge_represents_snapshot(item, snapshot)
+            for item in archived
+            if isinstance(item, dict)
+        ):
+            return
+
+        recovered = self._charge_from_fordpass_snapshot(snapshot)
+        if recovered is None:
+            return
+
+        if await self._charge_id_is_archived(recovered.charge_id):
+            return
+
+        _LOGGER.warning(
+            "Recovering recent FordPass Last Charge missing from archive: %s",
+            recovered.charge_id,
+        )
+        self.current_charge = recovered
+        await self.storage.save_current_charge(recovered.to_dict())
+        await self._finalize_charge(self._read_vehicle_state())
+
     def _last_charge_matches_current_charge(
         self,
         snapshot: dict[str, Any] | None,
@@ -987,17 +1344,25 @@ class FordTriplogCoordinator(DataUpdateCoordinator):
             return True
 
         tolerance_seconds = 900
-        tolerance = timedelta(seconds=tolerance_seconds)
 
         if ford_start is None:
             ford_start = ford_end
         if ford_end is None:
             ford_end = ford_start
 
-        matches = (
-            ford_start <= local_end + tolerance
-            and ford_end >= local_start - tolerance
-        )
+        # The previous interval-overlap check could accept an old FordPass
+        # dataset when a stale recovered charge accidentally spanned multiple
+        # days. The charge end is the strongest correlation point and must be
+        # close to FordPass. When both starts are available, validate those as
+        # well.
+        end_matches = abs(
+            (ford_end - local_end).total_seconds()
+        ) <= tolerance_seconds
+        start_matches = abs(
+            (ford_start - local_start).total_seconds()
+        ) <= tolerance_seconds
+
+        matches = end_matches and start_matches
 
         if not matches:
             _LOGGER.debug(
@@ -1412,6 +1777,24 @@ class FordTriplogCoordinator(DataUpdateCoordinator):
         """Start charging session."""
 
         async with self._charge_lock:
+            # A recovered current_charge must never block a new real charging
+            # edge when that exact charge already exists in the archive.
+            if (
+                self.current_charge is not None
+                and await self._charge_id_is_archived(
+                    self.current_charge.charge_id
+                )
+            ):
+                stale_charge_id = self.current_charge.charge_id
+                self._stop_waiting_for_last_charge()
+                await self.storage.delete_current_charge()
+                self.current_charge = None
+                _LOGGER.warning(
+                    "Discarded stale archived current charge %s before "
+                    "starting a new charging session",
+                    stale_charge_id,
+                )
+
             # A new IN_PROGRESS event permanently closes a previous session
             # that was still waiting for delayed FordPass data.
             if self.waiting_for_last_charge and self.current_charge:

--- a/custom_components/ford_triplog/coordinator.py
+++ b/custom_components/ford_triplog/coordinator.py
@@ -2103,6 +2103,43 @@ class FordTriplogCoordinator(DataUpdateCoordinator):
 
             await self.history.refresh_statistics()
 
+            # Keep the daily Journey archive synchronized with completed
+            # charging sessions, including late FordPass Last Charge recovery.
+            # This mirrors the existing automatic Journey rebuild after a trip.
+            if self.journey_rebuilder is not None:
+                try:
+                    start_time = dt_util.parse_datetime(
+                        str(charge.get("start_time") or "")
+                    )
+
+                    if start_time is None:
+                        raise ValueError(
+                            "Saved charge has no valid start_time"
+                        )
+
+                    if start_time.tzinfo is None:
+                        start_time = start_time.replace(
+                            tzinfo=dt_util.UTC
+                        )
+
+                    journey_date = dt_util.as_local(start_time).date()
+
+                    await self.journey_rebuilder.async_rebuild_journeys(
+                        start_date=journey_date,
+                        end_date=journey_date,
+                    )
+
+                    _LOGGER.info(
+                        "Journey rebuilt automatically for %s after charge %s",
+                        journey_date,
+                        charge.get("charge_id"),
+                    )
+                except Exception:  # noqa: BLE001
+                    _LOGGER.exception(
+                        "Automatic Journey rebuild failed after charge %s",
+                        charge.get("charge_id"),
+                    )
+
             if self.current_charge is charge_obj:
                 await self.storage.delete_current_charge()
                 self.current_charge = None

--- a/custom_components/ford_triplog/coordinator.py
+++ b/custom_components/ford_triplog/coordinator.py
@@ -4,7 +4,7 @@ Ford Triplog
 Coordinator
 
 Version: 2.3.0
-Build: 23031 - Charging recovery and Last Charge guard
+Build: 23032 - Late Last Charge backfill
 
 Changes:
 - Discards stale current_charge recovery records that are already archived.
@@ -14,6 +14,8 @@ Changes:
 - Repairs grossly corrupted archived charge end data from its embedded FordPass snapshot.
 - Removes a duplicate pending-charge timeout resume call.
 - Keeps the Build 23030 trip transition race guard.
+- Re-runs recent Last Charge archive reconciliation when FordPass publishes
+  the completed ChargeData only after Ford Triplog startup.
 """
 
 from __future__ import annotations
@@ -759,6 +761,20 @@ class FordTriplogCoordinator(DataUpdateCoordinator):
         )
 
         if not self.waiting_for_last_charge:
+            # FordPass commonly restores/publishes its Last Charge entity a few
+            # seconds after Ford Triplog has completed async_setup(). Build
+            # 23031 only reconciled once during startup, so a recent missing
+            # charge could still be skipped if the fresh ChargeData arrived
+            # afterwards. Re-run the guarded reconciliation for this late
+            # dataset. The archive/time/active-charging checks inside the
+            # reconcile method keep this idempotent and safe.
+            if (
+                self.current_charge is None
+                and self.last_charge_snapshot is not None
+            ):
+                self.hass.async_create_task(
+                    self._async_reconcile_late_last_charge()
+                )
             return
 
         if self.current_charge is None:
@@ -771,6 +787,19 @@ class FordTriplogCoordinator(DataUpdateCoordinator):
             return
 
         self._restart_last_charge_timer()
+
+    async def _async_reconcile_late_last_charge(self) -> None:
+        """Backfill a recent Last Charge that arrived after integration setup."""
+
+        async with self._charge_lock:
+            if self.waiting_for_last_charge or self.current_charge is not None:
+                return
+
+            _LOGGER.debug(
+                "Late FordPass Last Charge update received; "
+                "checking for missing archived charging session"
+            )
+            await self._async_reconcile_last_charge_archive()
 
     def _start_waiting_for_last_charge(
         self,

--- a/custom_components/ford_triplog/sensor.py
+++ b/custom_components/ford_triplog/sensor.py
@@ -1146,9 +1146,25 @@ class FordTriplogJourneyHistorySensor(FordTriplogLastJourneyOverviewSensor):
         return f"route_history_selected_date_{self.entry_id}"
 
     async def async_added_to_hass(self) -> None:
+        """Load state and subscribe to Journey rebuild/update notifications."""
+
         data = self.hass.data[DOMAIN][self.entry_id]
         data["journey_history_sensor"] = self
         self._selected_date = data.get(self._selection_key)
+
+        # This subclass overrides the parent lifecycle hook, so it must
+        # explicitly retain the parent Journey update subscription. Without
+        # this, a rebuilt Journey is written to SQLite but the selected-date
+        # History sensor keeps its stale attributes until the date is changed
+        # or the integration is reloaded.
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_LAST_JOURNEY_UPDATED,
+                self._handle_journey_update,
+            )
+        )
+
         await self._async_refresh()
 
     async def async_will_remove_from_hass(self) -> None:

--- a/custom_components/ford_triplog/strings.json
+++ b/custom_components/ford_triplog/strings.json
@@ -503,14 +503,16 @@
           "charge_receipt_ocr": "Run OCR again",
           "charge_receipt_delete": "Delete receipt",
           "charge_receipt_list": "Back to receipts",
-          "charge_receipt_parser_create": "Create parser profile"
+          "charge_receipt_parser_create": "Create parser profile",
+          "charge_receipt_apply": "Review receipt values"
         },
         "menu_option_descriptions": {
           "charge_receipt_open": "Display the original file in the browser.",
           "charge_receipt_ocr": "Analyze the receipt again and update parser values.",
           "charge_receipt_delete": "Delete the receipt file and stored metadata.",
           "charge_receipt_list": "Return to the receipt list for this charging session.",
-          "charge_receipt_parser_create": "Create a custom parser profile from the existing OCR text."
+          "charge_receipt_parser_create": "Create a custom parser profile from the existing OCR text.",
+          "charge_receipt_apply": "Review, correct and apply the detected billing values to this charging session."
         }
       },
       "charge_receipt_ocr": {

--- a/custom_components/ford_triplog/translations/de.json
+++ b/custom_components/ford_triplog/translations/de.json
@@ -506,14 +506,16 @@
           "charge_receipt_ocr": "OCR erneut ausführen",
           "charge_receipt_delete": "Beleg löschen",
           "charge_receipt_list": "Zurück zu den Belegen",
-          "charge_receipt_parser_create": "Parserprofil erstellen"
+          "charge_receipt_parser_create": "Parserprofil erstellen",
+          "charge_receipt_apply": "Belegwerte prüfen"
         },
         "menu_option_descriptions": {
           "charge_receipt_open": "Originaldatei im Browser anzeigen.",
           "charge_receipt_ocr": "Beleg erneut analysieren und Parserwerte aktualisieren.",
           "charge_receipt_delete": "Belegdatei und gespeicherte Metadaten löschen.",
           "charge_receipt_list": "Zur Belegliste dieses Ladevorgangs zurückkehren.",
-          "charge_receipt_parser_create": "Aus dem vorhandenen OCR-Text ein eigenes Parserprofil anlegen."
+          "charge_receipt_parser_create": "Aus dem vorhandenen OCR-Text ein eigenes Parserprofil anlegen.",
+          "charge_receipt_apply": "Erkannte Abrechnungswerte prüfen, korrigieren und auf diesen Ladevorgang übernehmen."
         }
       },
       "charge_receipt_ocr": {

--- a/custom_components/ford_triplog/translations/en.json
+++ b/custom_components/ford_triplog/translations/en.json
@@ -506,14 +506,16 @@
           "charge_receipt_ocr": "Run OCR again",
           "charge_receipt_delete": "Delete receipt",
           "charge_receipt_list": "Back to receipts",
-          "charge_receipt_parser_create": "Create parser profile"
+          "charge_receipt_parser_create": "Create parser profile",
+          "charge_receipt_apply": "Review receipt values"
         },
         "menu_option_descriptions": {
           "charge_receipt_open": "Display the original file in the browser.",
           "charge_receipt_ocr": "Analyze the receipt again and update parser values.",
           "charge_receipt_delete": "Delete the receipt file and stored metadata.",
           "charge_receipt_list": "Return to the receipt list for this charging session.",
-          "charge_receipt_parser_create": "Create a custom parser profile from the existing OCR text."
+          "charge_receipt_parser_create": "Create a custom parser profile from the existing OCR text.",
+          "charge_receipt_apply": "Review, correct and apply the detected billing values to this charging session."
         }
       },
       "charge_receipt_ocr": {

--- a/custom_components/ford_triplog/translations/pl.json
+++ b/custom_components/ford_triplog/translations/pl.json
@@ -506,14 +506,16 @@
           "charge_receipt_ocr": "Uruchom OCR ponownie",
           "charge_receipt_delete": "Usuń paragon",
           "charge_receipt_list": "Wróć do paragonów",
-          "charge_receipt_parser_create": "Utwórz profil parsera"
+          "charge_receipt_parser_create": "Utwórz profil parsera",
+          "charge_receipt_apply": "Sprawdź wartości paragonu"
         },
         "menu_option_descriptions": {
           "charge_receipt_open": "Wyświetl oryginalny plik w przeglądarce.",
           "charge_receipt_ocr": "Ponownie przeanalizuj paragon i zaktualizuj wartości parsera.",
           "charge_receipt_delete": "Usuń plik paragonu i zapisane metadane.",
           "charge_receipt_list": "Wróć do listy paragonów tej sesji ładowania.",
-          "charge_receipt_parser_create": "Utwórz własny profil parsera na podstawie istniejącego tekstu OCR."
+          "charge_receipt_parser_create": "Utwórz własny profil parsera na podstawie istniejącego tekstu OCR.",
+          "charge_receipt_apply": "Sprawdź, popraw i zastosuj wykryte wartości rozliczeniowe do tej sesji ładowania."
         }
       },
       "charge_receipt_ocr": {


### PR DESCRIPTION
## Ford Triplog 2.3.0 Pre-Release Update

This pre-release update contains several fixes found during real-world testing of the new SQLite, Route Tracker and charging workflows.

### Fixed

- Fixed duplicate Trip start/end processing caused by simultaneous Home Assistant state updates
- Improved protection against stale `current_charge` recovery data
- Prevented already archived charging sessions from being restored as active sessions
- Improved FordPass Last Charge timestamp validation
- Added recovery for completed FordPass charging sessions that were reported only after Ford Triplog startup
- Late recovered charging sessions are now added to the SQLite archive automatically
- Charging location and tariff handling improved for completed charging sessions
- Fixed receipt dialog translation placeholder error
- Fixed applying OCR/parser billing values to charging sessions
- Added the ability to review and re-apply parsed receipt values
- Journey History now refreshes correctly after a Journey rebuild
- Completed or recovered charging sessions now automatically rebuild the affected Journey day
- Charging energy, charging duration and receipt costs are therefore reflected immediately in Journey statistics

### Route Tracker

The Route Tracker changes introduced with 2.3 continue to be tested successfully:

- Direct Home Assistant `device_tracker` GPS support
- Dense GPS traces from the Home Assistant Companion App
- SQLite route snapshots limited to approximately once per 60 seconds while driving
- Immediate persistence on Trip start, pause, shutdown and finalization
- OSRM matching of long routes using overlapping chunks
- Raw GPS data is always preserved

A real-world test route with more than 1,100 raw GPS points and approximately 53 km was successfully processed and matched by OSRM.

### Charging Recovery

FordPass may publish the completed `Last Charge` dataset several seconds after Ford Triplog or Home Assistant has already started.

Ford Triplog 2.3 now detects this situation and can automatically recover a recent charging session that is missing from the archive.

Recovered charging sessions also trigger a rebuild of the affected Journey so energy and charging statistics remain consistent.

### Receipt / OCR Improvements

Receipt handling received several fixes during pre-release testing:

- OCR/parser values can be applied correctly to a charging session
- Parsed values can be reviewed and corrected before saving
- Previously parsed receipts can be applied again if an earlier save failed
- OCR-derived costs are stored with their correct source and are protected from automatic tariff recalculation

### Status

2.3 remains a **pre-release** while extended real-world testing continues.

Feedback about:

- Trip and Smart Trip behavior
- charging session detection and recovery
- Journey reconstruction
- Route Tracker / OSRM
- SQLite migration and recovery
- receipt/OCR handling

is especially welcome.